### PR TITLE
Bueller for bumping gem versions with rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,18 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "bueller"
 
 task :default => [:test]
 
+Bueller::Tasks.new
+
 RSpec::Core::RakeTask.new(:test)
+
+desc "Run RSpec tests"
 task :test => :spec
 
+desc "Run a console with baton lib loaded"
 task :console do
   sh "irb -rubygems -I lib -r baton.rb"
 end

--- a/baton.gemspec
+++ b/baton.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "chef", ">= 11.0"
   gem.add_runtime_dependency "thor"
 
+  gem.add_development_dependency "bueller", "~> 0.0.9"
   gem.add_development_dependency "rspec", "~> 2.7"
   gem.add_development_dependency "moqueue", "~> 0.1.4"
   gem.add_development_dependency "fakefs", "~> 0.4.0"


### PR DESCRIPTION
We can then use these tasks for bumping gem versions:

```
bundle exec rake version:bump:major
bundle exec rake version:bump:minor
bundle exec rake version:bump:patch
```
