### PR TITLE
Reconnect if we get a skipped heartbeat

### DIFF
--- a/lib/baton/channel.rb
+++ b/lib/baton/channel.rb
@@ -31,6 +31,7 @@ module Baton
 
       # Attach callbacks for error handling
       @connection.on_tcp_connection_loss(&method(:handle_tcp_failure))
+      @connection.on_skipped_heartbeats(&method(:handle_tcp_failure))
       @channel.on_error(&method(:handle_channel_exception))
     end
 


### PR DESCRIPTION
Reconnect to AMQP if we get a skipped heartbeat.

Currently we detect the skipped heartbeat but we don't do anything about it, and we won't reconnect until the tcp connection is lost.
