### PR TITLE
Update ohai dependancy to use current ohai version

### DIFF
--- a/baton.gemspec
+++ b/baton.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "eventmachine", "~> 1.0.0"
   gem.add_runtime_dependency "em-http-request", "1.0.3"
   gem.add_runtime_dependency "bunny", "~> 0.8.0"
-  gem.add_runtime_dependency "ohai", "~> 0.6.12"
+  gem.add_runtime_dependency "ohai", ">= 6.16"
   gem.add_runtime_dependency "chef", ">= 11.0"
   gem.add_runtime_dependency "thor"
 


### PR DESCRIPTION
Ohai 6 release are versioned 6.x.x.

Update the gemspec to use this new versioning.
